### PR TITLE
fix: add multi-byte char encode ability to WritePacketExt trait

### DIFF
--- a/src/packet_ext.rs
+++ b/src/packet_ext.rs
@@ -40,12 +40,14 @@ pub trait WritePacketExt: WriteBytesExt {
 impl WritePacketExt for Cursor<Vec<u8>> {
     fn write_cstring(&mut self, src: &str) -> Result<()> {
         for ch in src.chars() {
-            let mut chu8 = [0; 1];
-            ch.encode_utf8(&mut chu8);
-            self.write_u8(chu8[0])?;
+            // increase buffer size to allow encoding CJK or emoji characters
+            let mut chu8 = [0; 8];
+            let codes = ch.encode_utf8(&mut chu8);
+            for code in codes.as_bytes() {
+                self.write_u8(*code)?;
+            }
         }
         self.write_u8(0x00)?; // 0x00 Terminated
         Ok(())
     }
 }
-


### PR DESCRIPTION
In the old version, user just can use ascii chars in filter (such as `.name_match('abc*')`), 
So I increase the `chu8` buffer size to enable Unicode encoding.